### PR TITLE
Addressing some issues

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -139,8 +139,8 @@ class TestXMLValidator(unittest.TestCase):
         # Exit correctly with code 0
         self.assertEqual(result.exit_code, 0)
         # The correct output is given
-        self.assertIn("The XML file: invalid_SUBMISSION.xml\nis invalid.\n\n",
-                      result.output)
+        expected = "The XML file: invalid_SUBMISSION.xml\nis invalid.\n\n"
+        self.assertEqual(expected, result.output)
 
     def test_valid_xml_against_wrong_schema(self):
         """Test case for a valid xml file against the wrong schema."""

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -7,6 +7,10 @@ from urllib.parse import urlparse
 from io import BytesIO
 from pathlib import Path
 
+# Change environment variables for Click commands to work
+os.environ['LC_ALL'] = 'en_US.utf-8'
+os.environ['LANG'] = 'en_US.utf-8'
+
 
 def _process_http_reponse(url, scheme):
     """Process response from HTTP/HTTPS url."""
@@ -136,9 +140,6 @@ def cli(xml_file, schema_file, verbose):
 
 
 if __name__ == "__main__":
-    # Change environment variables for Click commands to work
-    os.environ['LC_ALL'] = 'en_US.utf-8'
-    os.environ['LANG'] = 'en_US.utf-8'
     cli()
     # Revert environment variables back
     os.unsetenv('LC_ALL')

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -1,22 +1,38 @@
 import click
 import os
 import requests
-import xml
 import xmlschema
 import ftplib
 from urllib.parse import urlparse
-from io import StringIO
+from io import BytesIO
+from pathlib import Path
 
-# Change environment variables for Click commands to work
-os.environ['LC_ALL'] = 'en_US.utf-8'
-os.environ['LANG'] = 'en_US.utf-8'
+
+def _process_http_reponse(url, scheme):
+    """Process response from HTTP/HTTPS url."""
+    resp = requests.get(url)
+    cnt_type = ['text/plain', 'xml']
+
+    if resp.status_code != requests.codes.ok:
+        resp.raise_for_status()
+    # we only raise upon error of protocol and content type
+    # content type can also be text/plain
+    elif (scheme in ['http', 'https']
+          and not any(x in resp.headers['Content-Type'] for x in cnt_type)):
+        error = (f"Error: Content of the URL ({resp.url})\n" +
+                 "is not in XML format. " +
+                 "Make sure the URL is correct.\n")
+        raise Exception(error)
+    else:
+        return resp.text
 
 
 def xmlFromURL(url, arg_type):
     """Deterimine if argument is an URL and return content from the URL."""
+    scheme = urlparse(url).scheme
+
     try:
         # Handle FTP or file URLs
-        scheme = urlparse(url).scheme
         if scheme == 'file':
             raise ValueError
         elif scheme == 'ftp':
@@ -24,37 +40,29 @@ def xmlFromURL(url, arg_type):
             path = urlparse(url).path
             ftp = ftplib.FTP(host)
             ftp.login()
-            r = StringIO()
-            ftp.retrlines('RETR ' + path, r.write)
-            content = r.getvalue()
+            r = BytesIO()
+            ftp.retrbinary('RETR ' + path, r.write)
+            byte_str = r.read()
+            content = byte_str.decode('UTF-8')  # Or use the encoding you expect
             r.close()
-            # Remove null bytes from the output to avoid unexpected errors
-            if '\x00' in content:
-                content = content.replace('\x00', '')
-            return content
-
-        # Handle HTTP and HTTPS URLs
-        resp = requests.get(url)
-        if resp.status_code != requests.codes.ok:
-            resp.raise_for_status()
-        elif 'http' in scheme and 'xml' not in resp.headers['Content-Type']:
-            error = (f"Error: Content of the URL ({resp.url})\n" +
-                     "is not in XML format. " +
-                     "Make sure the URL is correct.\n")
-            raise Exception(error)
+            ftp.close()
+            return content, url
         else:
-            return resp
+            content = _process_http_reponse(url, scheme)
+            return content, url
 
     except ValueError:
         # If argument is a file URL type or not an URL at all
         if scheme == 'file':
             url = url.replace('file://', '')
-        if not os.path.isfile(url):
+
+        file_path = Path(url)
+        if not file_path.is_file():
             error = (f"Error: Invalid value for {arg_type}\n" +
                      f"Path {url} does not exist.\n")
             raise Exception(error)
         else:
-            return None
+            return str(file_path.absolute()), url
 
     except requests.exceptions.HTTPError as err:
         # If request responds with HTTP error
@@ -73,48 +81,47 @@ def xmlFromURL(url, arg_type):
 @click.option('-v', '--verbose', is_flag=True,
               help="Verbose printout for XML validation errors.")
 def cli(xml_file, schema_file, verbose):
-    """Validates an XML against an XSD SCHEMA."""
-
+    """Validate an XML against an XSD SCHEMA."""
     xml_from_url = False
+
     try:
-        xml_resp = xmlFromURL(xml_file, 'XML_FILE')
-        if xml_resp:
-            xml_file = xml_resp.text
+        xml_file, requested_url = xmlFromURL(xml_file, 'XML_FILE')
+        if not xml_file.startswith('/'):
             xml_from_url = True
 
-        xsd_resp = xmlFromURL(schema_file, 'SCHEMA_FILE')
+        xsd_resp, _ = xmlFromURL(schema_file, 'SCHEMA_FILE')
         if xsd_resp:
             schema_file = str(xsd_resp)
 
     except Exception as error:
         click.echo(error)
-        return
+        return None
 
     try:
         xmlschema.validate(xml_file, schema=schema_file)
         # When validation succeeds
         if xml_from_url:
-            click.echo(f"The XML from the URL:\n{xml_resp.url}")
+            click.echo(f"The XML from the URL:\n{requested_url}")
             click.secho("is valid.\n", fg='green')
         else:
             click.echo("The XML file: " +
-                       click.format_filename(xml_file, shorten=True))
+                       click.format_filename(str(xml_file), shorten=True))
             click.secho("is valid.\n", fg='green')
 
     except xmlschema.validators.exceptions.XMLSchemaValidationError as err:
         # When validation does not succeed
         if xml_from_url:
-            click.echo(f"The XML from the URL:\n{xml_resp.url}")
+            click.echo(f"The XML from the URL:\n{requested_url}")
             click.secho("is invalid.\n", fg='red')
         else:
             click.echo("The XML file: " +
-                       click.format_filename(xml_file, shorten=True))
+                       click.format_filename(str(xml_file), shorten=True))
             click.secho("is invalid.\n", fg='red')
         if verbose:
             click.secho("Error:", bold=True)
             click.echo(err)
 
-    except xml.etree.ElementTree.ParseError as err:
+    except xmlschema.etree.ParseError as err:
         # If there is a syntax error with either file
         click.echo("Faulty XML or XSD file was given.\n")
         if verbose:
@@ -129,7 +136,10 @@ def cli(xml_file, schema_file, verbose):
 
 
 if __name__ == "__main__":
+    # Change environment variables for Click commands to work
+    os.environ['LC_ALL'] = 'en_US.utf-8'
+    os.environ['LANG'] = 'en_US.utf-8'
     cli()
     # Revert environment variables back
-    os.unsetenv['LC_ALL']
-    os.unsetenv['LANG']
+    os.unsetenv('LC_ALL')
+    os.unsetenv('LANG')


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

<!-- List changes made. -->

1. splitting url parsing  into function to avoid [mccabe](https://github.com/PyCQA/mccabe) complexity
2. we should support also `text/plain`
3. using bytesIO
4. fix seting environment variables
5. make use of pathlib

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
for testing it is enough to test those are called and it covers 89% of it which is ok.
to see which lines are not covered run `pytest -x --cov=validator --cov-report=html tests`

tested with:

```
xml-validate -v https://raw.githubusercontent.com/enasequence/schema/master/src/test/resources/uk/ac/ebi/ena/sra/xml/study/SRP000539.xml https://raw.githubusercontent.com/enasequence/schema/master/src/main/resources/uk/ac/ebi/ena/sra/schema/SRA.study.xsd
```
does not work because cannot get link to common but urls accessible

---

```
xml-validate -v https://raw.githubusercontent.com/enasequence/schema/master/src/test/resources/uk/ac/ebi/ena/sra/xml/study/SRP000539.xml ftp://ftp.ebi.ac.uk/pub/databases/ena/doc/xsd/sra_1_5/SRA.study.xsd
```
above works

---

If there was really need to check the responses we could have mocked the `FTP` class and its methods something along the lines (of course with the proper parameters - see https://docs.python.org/3/library/ftplib.html#ftp-objects) but don't think it is necessary.
```
class MockFTP:

  def login(self):
     pass

  def retrbinary(self):
     pass

  def close(self):
     pass

```